### PR TITLE
Add an internal max code length to prevent underflow errors

### DIFF
--- a/OpenLocationCode/OpenLocationCode.cs
+++ b/OpenLocationCode/OpenLocationCode.cs
@@ -33,8 +33,11 @@ namespace Google.OpenLocationCode {
         // The maximum value for longitude in degrees.
         private static readonly int LongitudeMax = 180;
 
-        // Maxiumum code length using just lat/lng pair encoding.
+        // Maximum code length using just lat/lng pair encoding.
         private static readonly int PairCodeLength = 10;
+
+        // Maximum code length for any plus code
+        public static readonly int MaxCodeLength = 15;
 
         // Number of columns in the grid refinement method.
         private static readonly int GridColumns = 4;
@@ -63,6 +66,8 @@ namespace Google.OpenLocationCode {
         /// <param name="codeLength">The desired number of digits in the code.</param>
         /// <exception cref="ArgumentException">If the code lenght is not valid.</exception>
         public OpenLocationCode(double latitude, double longitude, int codeLength) {
+            // Limit the maximum number of digits in the code.
+            codeLength = Math.Min(codeLength, MaxCodeLength);
             // Check that the code length requested is valid.
             if (codeLength < 4 || (codeLength < PairCodeLength && codeLength % 2 == 1)) {
                 throw new ArgumentException("Illegal code length " + codeLength);
@@ -134,7 +139,6 @@ namespace Google.OpenLocationCode {
         public OpenLocationCode(double latitude, double longitude) : this(latitude, longitude, CodePrecisionNormal) { }
 
 
-
         /// <summary>
         /// Returns the string representation of the code.
         /// </summary>
@@ -177,6 +181,7 @@ namespace Google.OpenLocationCode {
             }
             // Strip padding and separator characters out of the code.
             string decoded = Code.Replace(Separator.ToString(), "").Replace(PaddingCharacter.ToString(), "");
+            int decodedCodeLength = Math.Min(decoded.Length, MaxCodeLength);
 
             int digit = 0;
             // The precisions are initially set to ENCODING_BASE^2 because they will be immediately divided.
@@ -187,7 +192,7 @@ namespace Google.OpenLocationCode {
             decimal westLongitude = 0;
 
             // Decode the digits.
-            while (digit < decoded.Length) {
+            while (digit < decodedCodeLength) {
                 if (digit < PairCodeLength) {
                     // Decode a pair of digits, the first being latitude and the second being longitude.
                     latPrecision /= EncodingBase;
@@ -293,7 +298,7 @@ namespace Google.OpenLocationCode {
             double range = Math.Max(
                 Math.Abs(referenceLatitude - codeArea.CenterLatitude),
                 Math.Abs(referenceLongitude - codeArea.CenterLongitude)
-           );
+            );
             // We are going to check to see if we can remove three pairs, two pairs or just one pair of
             // digits from the code.
             for (int i = 4; i >= 1; i--) {

--- a/OpenLocationCode/OpenLocationCode.nuspec
+++ b/OpenLocationCode/OpenLocationCode.nuspec
@@ -2,14 +2,14 @@
 <package>
   <metadata>
     <id>OpenLocationCode</id>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <title>OpenLocationCode</title>
     <authors>Jon McPherson</authors>
     <owners>JonMcPherson</owners>
     <licenseUrl>https://github.com/google/open-location-code/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/JonMcPherson/open-location-code</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>A C# (.NET Standard) implementation of the Google Open Location Code API.</description>
+    <description>The C# (.NET Standard) implementation of the Google Open Location Code API.</description>
     <tags>google open location code plus codes latitude longitude encode decode</tags>
     <dependencies>
       <group targetFramework=".NETStandard2.0" />

--- a/OpenLocationCodeTest/EncodingTest.cs
+++ b/OpenLocationCodeTest/EncodingTest.cs
@@ -35,22 +35,30 @@ public class EncodingTest {
                     codeLength = testData.Code.IndexOf("0");
                 }
                 Assert.True(testData.Code == OpenLocationCode.Encode(testData.Lat, testData.Lon, codeLength),
-                            $"Latitude {testData.Lat} and longitude {testData.Lon} were wrongly encoded.");
+                    $"Latitude {testData.Lat} and longitude {testData.Lon} were wrongly encoded.");
             }
         }
 
         [Fact]
         public void ShouldClipCoordinatesWhenExceedingMaximum() {
             Assert.True(OpenLocationCode.Encode(-90, 5) == OpenLocationCode.Encode(-91, 5),
-                        "Clipping of negative latitude doesn't work.");
+                "Clipping of negative latitude doesn't work.");
             Assert.True(OpenLocationCode.Encode(90, 5) == OpenLocationCode.Encode(91, 5),
-                        "Clipping of positive latitude doesn't work.");
+                "Clipping of positive latitude doesn't work.");
             Assert.True(OpenLocationCode.Encode(5, 175) == OpenLocationCode.Encode(5, -185),
-                        "Clipping of negative longitude doesn't work.");
+                "Clipping of negative longitude doesn't work.");
             Assert.True(OpenLocationCode.Encode(5, 175) == OpenLocationCode.Encode(5, -905),
-                        "Clipping of very long negative longitude doesn't work.");
+                "Clipping of very long negative longitude doesn't work.");
             Assert.True(OpenLocationCode.Encode(5, -175) == OpenLocationCode.Encode(5, 905),
-                        "Clipping of very long positive longitude doesn't work.");
+                "Clipping of very long positive longitude doesn't work.");
+        }
+
+        [Fact]
+        public void ShouldLimitCodeLengthWhenExceedingMaximum() {
+            string code = OpenLocationCode.Encode(51.3701125, -10.202665625, 1000000);
+
+            Assert.True(code.Length == OpenLocationCode.MaxCodeLength + 1,
+                "Encoded code should have a length of MaxCodeLength + 1 for the plus symbol");
         }
     }
 
@@ -61,13 +69,13 @@ public class EncodingTest {
                 var decoded = OpenLocationCode.Decode(testData.Code);
 
                 Assert.True(IsNear(testData.DecodedLatLo, decoded.SouthLatitude),
-                            $"Wrong low latitude for code {testData.Code}");
+                    $"Wrong low latitude for code {testData.Code}");
                 Assert.True(IsNear(testData.DecodedLatHi, decoded.NorthLatitude),
-                            $"Wrong high latitude for code {testData.Code}");
+                    $"Wrong high latitude for code {testData.Code}");
                 Assert.True(IsNear(testData.DecodedLonLo, decoded.WestLongitude),
-                            $"Wrong low longitude for code {testData.Code}");
+                    $"Wrong low longitude for code {testData.Code}");
                 Assert.True(IsNear(testData.DecodedLonHi, decoded.EastLongitude),
-                            $"Wrong high longitude for code {testData.Code}");
+                    $"Wrong high longitude for code {testData.Code}");
             }
         }
 
@@ -77,15 +85,15 @@ public class EncodingTest {
                 var olc = new OpenLocationCode(testData.Code);
                 var decoded = olc.Decode();
                 Assert.True(olc.Contains(decoded.CenterLatitude, decoded.CenterLongitude),
-                            $"Containment relation is broken for the decoded middle point of code {testData.Code}");
+                    $"Containment relation is broken for the decoded middle point of code {testData.Code}");
                 Assert.True(olc.Contains(decoded.SouthLatitude, decoded.WestLongitude),
-                            $"Containment relation is broken for the decoded bottom left corner of code {testData.Code}");
+                    $"Containment relation is broken for the decoded bottom left corner of code {testData.Code}");
                 Assert.False(olc.Contains(decoded.NorthLatitude, decoded.EastLongitude),
-                             $"Containment relation is broken for the decoded top right corner of code {testData.Code}");
+                    $"Containment relation is broken for the decoded top right corner of code {testData.Code}");
                 Assert.False(olc.Contains(decoded.SouthLatitude, decoded.EastLongitude),
-                             $"Containment relation is broken for the decoded bottom right corner of code {testData.Code}");
+                    $"Containment relation is broken for the decoded bottom right corner of code {testData.Code}");
                 Assert.False(olc.Contains(decoded.NorthLatitude, decoded.WestLongitude),
-                             $"Containment relation is broken for the decoded top left corner of code {testData.Code}");
+                    $"Containment relation is broken for the decoded top left corner of code {testData.Code}");
             }
         }
 

--- a/OpenLocationCodeTest/ValidityTest.cs
+++ b/OpenLocationCodeTest/ValidityTest.cs
@@ -32,8 +32,22 @@ public static class ValidityTest {
         public void ShouldTestValidityOfACode() {
             foreach (TestData testData in testDataList) {
                 Assert.True(testData.IsValid == OpenLocationCode.IsValidCode(testData.Code),
-                            $"Validity of code {testData.Code} is wrong.");
+                    $"Validity of code {testData.Code} is wrong.");
             }
+        }
+
+        [Fact]
+        public void ShouldValidateCodesExceedingMaximumLength() {
+            string code = OpenLocationCode.Encode(51.3701125, -10.202665625, 1000000);
+            Assert.True(OpenLocationCode.IsValidCode(code), "Code should be valid.");
+
+            // Extend the code with a valid character and make sure it is still valid.
+            Assert.True(OpenLocationCode.IsValidCode(code + "W"),
+                "Too long code with all valid characters should be valid.");
+
+            // Extend the code with an invalid character and make sure it is invalid.
+            Assert.False(OpenLocationCode.IsValidCode(code + "U"),
+                "Too long code with invalid character should be invalid.");
         }
     }
 
@@ -42,7 +56,7 @@ public static class ValidityTest {
         public void ShouldTestShortnessOfACode() {
             foreach (TestData testData in testDataList) {
                 Assert.True(testData.IsShort == OpenLocationCode.IsShortCode(testData.Code),
-                            $"Shortness of code {testData.Code} is wrong.");
+                    $"Shortness of code {testData.Code} is wrong.");
             }
         }
     }
@@ -52,7 +66,7 @@ public static class ValidityTest {
         public void ShouldTestFullnessOfACode() {
             foreach (TestData testData in testDataList) {
                 Assert.True(testData.IsFull == OpenLocationCode.IsFullCode(testData.Code),
-                            $"Fullness of code {testData.Code} is wrong.");
+                    $"Fullness of code {testData.Code} is wrong.");
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # open-location-code
 
-This is the C# (.NET Standard) implementation of the Google Open Location Code API ([google/open-location-code](https://github.com/google/open-location-code)).
+The C# (.NET Standard) implementation of the Google Open Location Code API ([google/open-location-code](https://github.com/google/open-location-code)).
 
-This implementation is a direct port of the [Java implementation](https://github.com/google/open-location-code/tree/master/java).
+This is a direct port of the [Java implementation](https://github.com/google/open-location-code/tree/master/java)
 
 ## NuGet Package
 


### PR DESCRIPTION
This is in response to issue https://github.com/JonMcPherson/open-location-code/issues/1
And https://github.com/google/open-location-code/issues/190