### PR TITLE
Release version 1.1.0 - Minor backward compatible additions and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@
 packages/
 TestResults/
 
+# IDEs
 .vs/
+.idea/
 
 # globs
 Makefile.in

--- a/OpenLocationCode/CodeArea.cs
+++ b/OpenLocationCode/CodeArea.cs
@@ -9,7 +9,7 @@ namespace Google.OpenLocationCode {
     public class CodeArea {
 
         public CodeArea(double southLatitude, double westLongitude, double northLatitude, double eastLongitude) :
-            this(new GeoCoord(westLongitude, southLatitude), new GeoCoord(eastLongitude, northLatitude)) { }
+            this(new GeoCoord(southLatitude, westLongitude), new GeoCoord(northLatitude, eastLongitude)) { }
 
         public CodeArea(GeoCoord min, GeoCoord max) {
             if (min.Longitude >= max.Longitude || min.Latitude >= max.Latitude) {
@@ -26,8 +26,8 @@ namespace Google.OpenLocationCode {
         public GeoCoord Max { get; }
 
         public GeoCoord Center => new GeoCoord(
-            (double) (((decimal) Min.Longitude + (decimal) Max.Longitude) / 2),
-            (double) (((decimal) Min.Latitude + (decimal) Max.Latitude) / 2)
+            (Min.Latitude + Max.Latitude) / 2,
+            (Min.Longitude + Max.Longitude) / 2
         );
 
         public double LongitudeWidth => (double) ((decimal) Max.Longitude - (decimal) Min.Longitude);

--- a/OpenLocationCode/CodeArea.cs
+++ b/OpenLocationCode/CodeArea.cs
@@ -2,16 +2,16 @@
 
 namespace Google.OpenLocationCode {
     /// <summary>
-    /// Coordinates of a decoded Open Location Code.
+    /// Coordinates of a decoded Open Location Code area.
     /// The coordinates include the latitude and longitude of the lower left and upper right corners
-    /// and the center of the bounding box for the area the code represents.
+    /// and the center of the bounding box of the code area.
     /// </summary>
     public class CodeArea {
 
         public CodeArea(double southLatitude, double westLongitude, double northLatitude, double eastLongitude) :
-            this(new GeoCoord(southLatitude, westLongitude), new GeoCoord(northLatitude, eastLongitude)) { }
+            this(new GeoPoint(southLatitude, westLongitude), new GeoPoint(northLatitude, eastLongitude)) { }
 
-        public CodeArea(GeoCoord min, GeoCoord max) {
+        public CodeArea(GeoPoint min, GeoPoint max) {
             if (min.Longitude >= max.Longitude || min.Latitude >= max.Latitude) {
                 throw new ArgumentException("min must be less than max");
             }
@@ -21,11 +21,11 @@ namespace Google.OpenLocationCode {
         }
 
 
-        public GeoCoord Min { get; }
+        public GeoPoint Min { get; }
 
-        public GeoCoord Max { get; }
+        public GeoPoint Max { get; }
 
-        public GeoCoord Center => new GeoCoord(
+        public GeoPoint Center => new GeoPoint(
             (Min.Latitude + Max.Latitude) / 2,
             (Min.Longitude + Max.Longitude) / 2
         );
@@ -48,7 +48,7 @@ namespace Google.OpenLocationCode {
         public double CenterLongitude => Center.Longitude;
 
 
-        public bool Contains(GeoCoord coordinates) {
+        public bool Contains(GeoPoint coordinates) {
             return Contains(coordinates.Longitude, coordinates.Latitude);
         }
 

--- a/OpenLocationCode/CodeArea.cs
+++ b/OpenLocationCode/CodeArea.cs
@@ -25,10 +25,7 @@ namespace Google.OpenLocationCode {
 
         public GeoPoint Max { get; }
 
-        public GeoPoint Center => new GeoPoint(
-            (Min.Latitude + Max.Latitude) / 2,
-            (Min.Longitude + Max.Longitude) / 2
-        );
+        public GeoPoint Center => new GeoPoint(CenterLatitude, CenterLongitude);
 
         public double LongitudeWidth => (double) ((decimal) Max.Longitude - (decimal) Min.Longitude);
 
@@ -43,9 +40,9 @@ namespace Google.OpenLocationCode {
 
         public double EastLongitude => Max.Longitude;
 
-        public double CenterLatitude => Center.Latitude;
+        public double CenterLatitude => (Min.Latitude + Max.Latitude) / 2;
 
-        public double CenterLongitude => Center.Longitude;
+        public double CenterLongitude => (Min.Longitude + Max.Longitude) / 2;
 
 
         public bool Contains(GeoPoint coordinates) {

--- a/OpenLocationCode/CodeArea.cs
+++ b/OpenLocationCode/CodeArea.cs
@@ -1,37 +1,61 @@
-﻿namespace Google.OpenLocationCode {
+﻿using System;
+
+namespace Google.OpenLocationCode {
     /// <summary>
     /// Coordinates of a decoded Open Location Code.
     /// The coordinates include the latitude and longitude of the lower left and upper right corners
     /// and the center of the bounding box for the area the code represents.
     /// </summary>
     public class CodeArea {
-        
-        public CodeArea(decimal southLatitude, decimal westLongitude, decimal northLatitude, decimal eastLongitude) {
-            SouthLatitude = (double) southLatitude;
-            WestLongitude = (double) westLongitude;
-            NorthLatitude = (double) northLatitude;
-            EastLongitude = (double) eastLongitude;
-            LatitudeHeight = (double) (northLatitude - southLatitude);
-            LongitudeWidth = (double) (eastLongitude - westLongitude);
-            CenterLatitude = (double) ((southLatitude + northLatitude) / 2);
-            CenterLongitude = (double) ((westLongitude + eastLongitude) / 2);
+
+        public CodeArea(double southLatitude, double westLongitude, double northLatitude, double eastLongitude) :
+            this(new GeoCoord(westLongitude, southLatitude), new GeoCoord(eastLongitude, northLatitude)) { }
+
+        public CodeArea(GeoCoord min, GeoCoord max) {
+            if (min.Longitude >= max.Longitude || min.Latitude >= max.Latitude) {
+                throw new ArgumentException("min must be less than max");
+            }
+
+            Min = min;
+            Max = max;
         }
 
-        public double SouthLatitude { get; }
 
-        public double WestLongitude { get; }
+        public GeoCoord Min { get; }
 
-        public double NorthLatitude { get; }
+        public GeoCoord Max { get; }
 
-        public double EastLongitude { get; }
+        public GeoCoord Center => new GeoCoord(
+            (double) (((decimal) Min.Longitude + (decimal) Max.Longitude) / 2),
+            (double) (((decimal) Min.Latitude + (decimal) Max.Latitude) / 2)
+        );
 
-        public double LatitudeHeight { get; }
+        public double LongitudeWidth => (double) ((decimal) Max.Longitude - (decimal) Min.Longitude);
 
-        public double LongitudeWidth { get; }
+        public double LatitudeHeight => (double) ((decimal) Max.Latitude - (decimal) Min.Latitude);
 
-        public double CenterLatitude { get; }
 
-        public double CenterLongitude { get; }
+        public double SouthLatitude => Min.Latitude;
+
+        public double WestLongitude => Min.Longitude;
+
+        public double NorthLatitude => Max.Latitude;
+
+        public double EastLongitude => Max.Longitude;
+
+        public double CenterLatitude => Center.Latitude;
+
+        public double CenterLongitude => Center.Longitude;
+
+
+        public bool Contains(GeoCoord coordinates) {
+            return Contains(coordinates.Longitude, coordinates.Latitude);
+        }
+
+        public bool Contains(double longitude, double latitude) {
+            return Min.Longitude <= longitude && longitude < Max.Longitude
+                && Min.Latitude <= latitude && latitude < Max.Latitude;
+        }
 
     }
 }

--- a/OpenLocationCode/GeoCoord.cs
+++ b/OpenLocationCode/GeoCoord.cs
@@ -1,0 +1,32 @@
+using System;
+namespace Google.OpenLocationCode {
+    public struct GeoCoord : IEquatable<GeoCoord> {
+
+        // [long, lat] to be consistent with [x, y] coordinate representation
+        public GeoCoord(double longitude, double latitude) {
+            if (longitude < -180 || longitude > 180) throw new ArgumentException("longitude is out of range -180 to 180");
+            if (latitude < -90 || latitude > 90) throw new ArgumentException("latitude is out of range -90 to 90");
+
+            Longitude = longitude;
+            Latitude = latitude;
+        }
+
+        public double Longitude { get; }
+
+        public double Latitude { get; }
+
+
+        public override string ToString() => $"[Longitude:{Longitude},Latitude:{Latitude}]";
+
+        public override int GetHashCode() => Longitude.GetHashCode() ^ Latitude.GetHashCode();
+
+        public override bool Equals(object obj) => obj is GeoCoord && Equals((GeoCoord) obj);
+
+        public bool Equals(GeoCoord other) => this == other;
+
+        public static bool operator ==(GeoCoord a, GeoCoord b) => a.Longitude == b.Longitude && a.Latitude == b.Latitude;
+
+        public static bool operator !=(GeoCoord a, GeoCoord b) => !(a == b);
+
+    }
+}

--- a/OpenLocationCode/GeoCoord.cs
+++ b/OpenLocationCode/GeoCoord.cs
@@ -2,18 +2,17 @@ using System;
 namespace Google.OpenLocationCode {
     public struct GeoCoord : IEquatable<GeoCoord> {
 
-        // [long, lat] to be consistent with [x, y] coordinate representation
-        public GeoCoord(double longitude, double latitude) {
-            if (longitude < -180 || longitude > 180) throw new ArgumentException("longitude is out of range -180 to 180");
+        public GeoCoord(double latitude, double longitude) {
             if (latitude < -90 || latitude > 90) throw new ArgumentException("latitude is out of range -90 to 90");
+            if (longitude < -180 || longitude > 180) throw new ArgumentException("longitude is out of range -180 to 180");
 
-            Longitude = longitude;
             Latitude = latitude;
+            Longitude = longitude;
         }
 
-        public double Longitude { get; }
-
         public double Latitude { get; }
+
+        public double Longitude { get; }
 
 
         public override string ToString() => $"[Longitude:{Longitude},Latitude:{Latitude}]";

--- a/OpenLocationCode/GeoPoint.cs
+++ b/OpenLocationCode/GeoPoint.cs
@@ -1,7 +1,14 @@
 using System;
 namespace Google.OpenLocationCode {
+    /// <summary>
+    /// A point on the three-dimensional geographic coordinate system specified by latitude and longigtude coordinates in degrees.
+    /// </summary>
     public struct GeoPoint : IEquatable<GeoPoint> {
 
+        /// <param name="latitude">The latitude coodinate in degrees</param>
+        /// <param name="longitude">The longitude coordinate in degrees</param>
+        /// <exception cref="ArgumentException">If latitude is out of range -90 to 90</exception>
+        /// <exception cref="ArgumentException">If longitude is out of range -180 to 180</exception>
         public GeoPoint(double latitude, double longitude) {
             if (latitude < -90 || latitude > 90) throw new ArgumentException("latitude is out of range -90 to 90");
             if (longitude < -180 || longitude > 180) throw new ArgumentException("longitude is out of range -180 to 180");
@@ -10,11 +17,18 @@ namespace Google.OpenLocationCode {
             Longitude = longitude;
         }
 
+        /// <summary>
+        /// The latitude coordinate in degrees (y axis)
+        /// </summary>
         public double Latitude { get; }
 
+        /// <summary>
+        /// The longitude coordinate in degrees (x axis)
+        /// </summary>
         public double Longitude { get; }
 
 
+        /// <returns>A human readable representation of this GeoPoint</returns>
         public override string ToString() => $"[Longitude:{Longitude},Latitude:{Latitude}]";
 
         public override int GetHashCode() => Longitude.GetHashCode() ^ Latitude.GetHashCode();

--- a/OpenLocationCode/GeoPoint.cs
+++ b/OpenLocationCode/GeoPoint.cs
@@ -1,8 +1,8 @@
 using System;
 namespace Google.OpenLocationCode {
-    public struct GeoCoord : IEquatable<GeoCoord> {
+    public struct GeoPoint : IEquatable<GeoPoint> {
 
-        public GeoCoord(double latitude, double longitude) {
+        public GeoPoint(double latitude, double longitude) {
             if (latitude < -90 || latitude > 90) throw new ArgumentException("latitude is out of range -90 to 90");
             if (longitude < -180 || longitude > 180) throw new ArgumentException("longitude is out of range -180 to 180");
 
@@ -19,13 +19,13 @@ namespace Google.OpenLocationCode {
 
         public override int GetHashCode() => Longitude.GetHashCode() ^ Latitude.GetHashCode();
 
-        public override bool Equals(object obj) => obj is GeoCoord && Equals((GeoCoord) obj);
+        public override bool Equals(object obj) => obj is GeoPoint coord && Equals(coord);
 
-        public bool Equals(GeoCoord other) => this == other;
+        public bool Equals(GeoPoint other) => this == other;
 
-        public static bool operator ==(GeoCoord a, GeoCoord b) => a.Longitude == b.Longitude && a.Latitude == b.Latitude;
+        public static bool operator ==(GeoPoint a, GeoPoint b) => a.Longitude == b.Longitude && a.Latitude == b.Latitude;
 
-        public static bool operator !=(GeoCoord a, GeoCoord b) => !(a == b);
+        public static bool operator !=(GeoPoint a, GeoPoint b) => !(a == b);
 
     }
 }

--- a/OpenLocationCode/OpenLocationCode.cs
+++ b/OpenLocationCode/OpenLocationCode.cs
@@ -563,10 +563,13 @@ namespace Google.OpenLocationCode {
         }
 
         /// <summary>
-        /// This will simply append padding '0' characters and append or insert the separator '+' character if necessary.
+        /// Pad a location code by applying the padding '0' and separator '+' characters that are necessary to form a valid location code.
+        /// If the given code is already padded, it will be returned as-is.
         /// </summary>
-        /// <param name="code">The trimmed code to pad into a valid code</param>
-        /// <returns>A padded code from a trimmed code (without any validation)</returns>
+        /// <remarks>
+        /// This will not do any validation of the provided code and will simply append or insert the characters if missing.
+        /// </remarks>
+        /// <param name="code">The code to pad</param>
         public static string PadCode(string code) {
             if (code.Length < SeparatorPosition) {
                 return code + new string(PaddingCharacter, SeparatorPosition - code.Length) + SeparatorCharacter;
@@ -579,10 +582,13 @@ namespace Google.OpenLocationCode {
         }
 
         /// <summary>
-        /// Trim or strip unnecessary characters from a location code. simply by removing any padding '0' and separator '+' characters.
+        /// Trim a location code by removing any padding '0' and separator '+' characters that are unnecessary to represent a location code.
+        /// If the code is already trimmed, it will be returned as-is.
         /// </summary>
+        /// <remarks>
+        /// This will not do any validation of the provided code and will simply strip the characters if they exist.
+        /// </remarks>
         /// <param name="code">the code to trim</param>
-        /// <returns>A trimmed code from a padded code (without any validation)</returns>
         public static string TrimCode(string code) {
             StringBuilder codeBuilder = new StringBuilder();
             foreach (char c in code) {
@@ -590,7 +596,7 @@ namespace Google.OpenLocationCode {
                     codeBuilder.Append(c);
                 }
             }
-            return codeBuilder.ToString();
+            return codeBuilder.Length != code.Length ? codeBuilder.ToString() : code;
         }
 
         // Private static methods.

--- a/OpenLocationCode/OpenLocationCode.cs
+++ b/OpenLocationCode/OpenLocationCode.cs
@@ -172,7 +172,7 @@ namespace Google.OpenLocationCode {
         /// </summary>
         /// <param name="coordinates">The geographic coordinates.</param>
         /// <param name="codeLength">The desired number of digits in the code.</param>
-        public OpenLocationCode(GeoCoord coordinates, int codeLength) :
+        public OpenLocationCode(GeoPoint coordinates, int codeLength) :
             this(coordinates.Latitude, coordinates.Longitude, codeLength) { }
 
         /// <summary>
@@ -186,7 +186,7 @@ namespace Google.OpenLocationCode {
         /// Creates Open Location Code with the default precision length of 10.
         /// </summary>
         /// <param name="coordinates">The geographic coordinates.</param>
-        public OpenLocationCode(GeoCoord coordinates) : this(coordinates.Latitude, coordinates.Longitude) { }
+        public OpenLocationCode(GeoPoint coordinates) : this(coordinates.Latitude, coordinates.Longitude) { }
 
         // Used internally for codes which are guaranteed to be valid
         internal OpenLocationCode(char[] codeChars) {
@@ -370,7 +370,7 @@ namespace Google.OpenLocationCode {
                 throw new InvalidOperationException("Shorten() method can not be called on a padded code.");
             }
 
-            GeoCoord center = Decode().Center;
+            GeoPoint center = Decode().Center;
             double range = Math.Max(
                 Math.Abs(referenceLatitude - center.Latitude),
                 Math.Abs(referenceLongitude - center.Longitude)
@@ -412,7 +412,7 @@ namespace Google.OpenLocationCode {
                 new OpenLocationCode(referenceLatitude, referenceLongitude).Code.Substring(0, digitsToRecover);
             // Combine the prefix with the short code and decode it.
             OpenLocationCode recovered = new OpenLocationCode(recoveredPrefix + Code);
-            GeoCoord recoveredCodeAreaCenter = recovered.Decode().Center;
+            GeoPoint recoveredCodeAreaCenter = recovered.Decode().Center;
             // Work out whether the new code area is too far from the reference location. If it is, we
             // move it. It can only be out by a single precision step.
             double recoveredLatitude = recoveredCodeAreaCenter.Latitude;

--- a/OpenLocationCode/OpenLocationCode.cs
+++ b/OpenLocationCode/OpenLocationCode.cs
@@ -4,58 +4,93 @@ using System.Text;
 namespace Google.OpenLocationCode {
     public sealed class OpenLocationCode {
 
-        // Provides a normal precision code, approximately 14x14 meters.
-        public static readonly int CodePrecisionNormal = 10;
+        /// <summary>
+        /// Provides a normal precision code, approximately 14x14 meters.
+        /// </summary>
+        public const int CodePrecisionNormal = 10;
 
-        // Provides an extra precision code, approximately 2x3 meters.
-        public static readonly int CodePrecisionExtra = 11;
+        /// <summary>
+        /// Provides an extra precision code, approximately 2x3 meters.
+        /// </summary>
+        public const int CodePrecisionExtra = 11;
+
 
         // A separator used to break the code into two parts to aid memorability.
-        private static readonly char Separator = '+';
+        private const char SeparatorCharacter = '+';
 
         // The number of characters to place before the separator.
-        private static readonly int SeparatorPosition = 8;
+        private const int SeparatorPosition = 8;
 
         // The character used to pad codes.
-        private static readonly char PaddingCharacter = '0';
+        private const char PaddingCharacter = '0';
 
-        // The character set used to encode the values.
-        private static readonly string CodeAlphabet = "23456789CFGHJMPQRVWX";
+        // The character set used to encode the digit values.
+        internal const string CodeAlphabet = "23456789CFGHJMPQRVWX";
+
+        // The maximum digit value in the code alphabet
+        internal static readonly int MaxDigitValue = CodeAlphabet.Length - 1;
+
+        // The maximum latitude digit value for the first grid layer
+        private const int FirstLatitudeDigitValueMax = 8; // lat -> 90
+
+        // The maximum longitude digit value for the first grid layer
+        internal const int FirstLongitudeDigitValueMax = 17; // lon -> 180
+
+        // The ASCII integer of the minimum digit character used as the offset for indexed code digits
+        private static readonly int IndexedDigitValueOffset = CodeAlphabet[0]; // 50
+
+        // The digit values indexed by the character ASCII integer for efficient lookup of a digit value by its character
+        private static readonly int[] IndexedDigitValues = new int[(CodeAlphabet[MaxDigitValue] - IndexedDigitValueOffset) + 1]; // int[38]
 
         // The base to use to convert numbers to/from.
-        private static readonly int EncodingBase = CodeAlphabet.Length;
+        internal static readonly int EncodingBase = CodeAlphabet.Length;
 
         private static readonly int EncodingBaseSquared = EncodingBase * EncodingBase;
 
         // The maximum value for latitude in degrees.
-        private static readonly int LatitudeMax = 90;
+        private const int LatitudeMax = 90;
 
         // The maximum value for longitude in degrees.
-        private static readonly int LongitudeMax = 180;
+        private const int LongitudeMax = 180;
 
         // Maximum code length using just lat/lng pair encoding.
-        private static readonly int PairCodeLength = 10;
+        internal const int PairCodeLength = 10;
 
         // Maximum code length for any plus code
         public static readonly int MaxCodeLength = 15;
 
         // Number of columns in the grid refinement method.
-        private static readonly int GridColumns = 4;
+        internal const int RefinementGridColumns = 4;
 
         // Number of rows in the grid refinement method.
-        private static readonly int GridRows = 5;
+        private const int RefinementGridRows = 5;
+
+        static OpenLocationCode() {
+            for (int i = 0, digitVal = 0; i < IndexedDigitValues.Length; i++) {
+                int digitIndex = CodeAlphabet[digitVal] - IndexedDigitValueOffset;
+                IndexedDigitValues[i] = (digitIndex == i) ? digitVal++ : -1;
+            }
+        }
+
+
+        private readonly Lazy<CodeArea> _codeArea;
 
 
         /// <summary>
         /// Creates Open Location Code object for the provided code.
         /// </summary>
         /// <param name="code">A valid OLC code. Can be a full code or a shortened code.</param>
-        /// <exception cref="ArgumentException">If the code is not valid.</exception>
+        /// <exception cref="ArgumentException">If the code is null or not valid.</exception>
         public OpenLocationCode(string code) {
-            if (!IsValidCode(code.ToUpper())) {
-                throw new ArgumentException($"The provided code '{code}' is not a valid Open Location Code.");
+            if (code == null) {
+                throw new ArgumentException("code cannot be null");
             }
             Code = code.ToUpper();
+            if (!IsValidCodeUpperCase(Code)) {
+                throw new ArgumentException($"The provided code '{code}' is not a valid Open Location Code.");
+            }
+
+            _codeArea = new Lazy<CodeArea>(() => DecodeValid(code));
         }
 
         /// <summary>
@@ -77,21 +112,21 @@ namespace Google.OpenLocationCode {
             longitude = NormalizeLongitude(longitude);
 
             // Latitude 90 needs to be adjusted to be just less, so the returned code can also be decoded.
-            if (latitude == LatitudeMax) {
+            if ((int) latitude == LatitudeMax) {
                 latitude = latitude - 0.9 * ComputeLatitudePrecision(codeLength);
             }
 
             // Adjust latitude and longitude to be in positive number ranges.
-            decimal remainingLatitude = (decimal) latitude + LatitudeMax;
-            decimal remainingLongitude = (decimal) longitude + LongitudeMax;
+            double remainingLatitude = latitude + LatitudeMax;
+            double remainingLongitude = longitude + LongitudeMax;
 
             // Count how many digits have been created.
             int generatedDigits = 0;
             // Store the code.
             StringBuilder codeBuilder = new StringBuilder();
             // The precisions are initially set to ENCODING_BASE^2 because they will be immediately divided.
-            decimal latPrecision = EncodingBaseSquared;
-            decimal lngPrecision = EncodingBaseSquared;
+            double latPrecision = EncodingBaseSquared;
+            double lngPrecision = EncodingBaseSquared;
             while (generatedDigits < codeLength) {
                 if (generatedDigits < PairCodeLength) {
                     // Use the normal algorithm for the first set of digits.
@@ -106,18 +141,18 @@ namespace Google.OpenLocationCode {
                     generatedDigits += 2;
                 } else {
                     // Use the 4x5 grid for remaining digits.
-                    latPrecision /= GridRows;
-                    lngPrecision /= GridColumns;
+                    latPrecision /= RefinementGridRows;
+                    lngPrecision /= RefinementGridColumns;
                     int row = (int) Math.Floor(remainingLatitude / latPrecision);
                     int col = (int) Math.Floor(remainingLongitude / lngPrecision);
                     remainingLatitude -= latPrecision * row;
                     remainingLongitude -= lngPrecision * col;
-                    codeBuilder.Append(CodeAlphabet[row * GridColumns + col]);
+                    codeBuilder.Append(CodeAlphabet[row * RefinementGridColumns + col]);
                     generatedDigits += 1;
                 }
                 // If we are at the separator position, add the separator.
                 if (generatedDigits == SeparatorPosition) {
-                    codeBuilder.Append(Separator);
+                    codeBuilder.Append(SeparatorCharacter);
                 }
             }
             // If the generated code is shorter than the separator position, pad the code and add the
@@ -126,17 +161,38 @@ namespace Google.OpenLocationCode {
                 for (; generatedDigits < SeparatorPosition; generatedDigits++) {
                     codeBuilder.Append(PaddingCharacter);
                 }
-                codeBuilder.Append(Separator);
+                codeBuilder.Append(SeparatorCharacter);
             }
             Code = codeBuilder.ToString();
+            _codeArea = new Lazy<CodeArea>(() => DecodeValid(Code));
         }
 
         /// <summary>
-        /// Creates Open Location Code with the default precision length.
+        /// Creates Open Location Code.
+        /// </summary>
+        /// <param name="coordinates">The geographic coordinates.</param>
+        /// <param name="codeLength">The desired number of digits in the code.</param>
+        public OpenLocationCode(GeoCoord coordinates, int codeLength) :
+            this(coordinates.Latitude, coordinates.Longitude, codeLength) { }
+
+        /// <summary>
+        /// Creates Open Location Code with the default precision length of 10.
         /// </summary>
         /// <param name="latitude">The latitude in decimal degrees.</param>
         /// <param name="longitude">The longitude in decimal degrees.</param>
         public OpenLocationCode(double latitude, double longitude) : this(latitude, longitude, CodePrecisionNormal) { }
+
+        /// <summary>
+        /// Creates Open Location Code with the default precision length of 10.
+        /// </summary>
+        /// <param name="coordinates">The geographic coordinates.</param>
+        public OpenLocationCode(GeoCoord coordinates) : this(coordinates.Latitude, coordinates.Longitude) { }
+
+        // Used internally for codes which are guaranteed to be valid
+        internal OpenLocationCode(char[] codeChars) {
+            Code = PadCode(new string(codeChars));
+            _codeArea = new Lazy<CodeArea>(() => DecodeValid(Code));
+        }
 
 
         /// <summary>
@@ -147,7 +203,7 @@ namespace Google.OpenLocationCode {
 
 
         /// <summary>
-        /// Encodes latitude/longitude into 10 digit Open Location Code.
+        /// Encodes latitude/longitude into a 10 digit Open Location Code.
         /// This method is equivalent to creating the OpenLocationCode object and getting the code from it.
         /// </summary>
         /// <returns>The encoded Open Location Code.</returns>
@@ -158,7 +214,7 @@ namespace Google.OpenLocationCode {
         }
 
         /// <summary>
-        /// Encodes latitude/longitude into Open Location Code of the provided length.
+        /// Encodes latitude/longitude into an Open Location Code of the provided length.
         /// This method is equivalent to creating the OpenLocationCode object and getting the code from it.
         /// </summary>
         /// <returns>The encoded Open Location Code.</returns>
@@ -170,26 +226,33 @@ namespace Google.OpenLocationCode {
             return new OpenLocationCode(latitude, longitude, codeLength).Code;
         }
 
-        /// <summary>
-        /// Decodes this Open Location Code into CodeArea object encapsulating latitude/longitude bounding box.
+        /// /// <summary>
+        /// Decodes an Open Location Code into CodeArea object encapsulating latitude/longitude bounding box.
         /// </summary>
-        /// <returns>The decoded CodeArea for this Open Location Code.</returns>
-        /// <exception cref="InvalidOperationException">If this code is not full.</exception>
-        public CodeArea Decode() {
-            if (!IsFullCode(Code)) {
-                throw new InvalidOperationException($"Method Decode() could only be called on valid full codes, code was {Code}.");
+        /// <returns>The decoded CodeArea for the given location code.</returns>
+        /// <param name="code">The Open Location Code to be decoded.</param>
+        /// <exception cref="ArgumentException">If the code is not valid.</exception>
+        /// <exception cref="InvalidOperationException">If the code is not full.</exception>
+        public static CodeArea Decode(string code) {
+            return new OpenLocationCode(code).Decode();
+        }
+
+        // Decode() without any validity checks
+        private static CodeArea DecodeValid(string code) {
+            if (!IsCodeFull(code)) {
+                throw new InvalidOperationException($"Method Decode() could only be called on valid full codes, code was {code}.");
             }
             // Strip padding and separator characters out of the code.
-            string decoded = Code.Replace(Separator.ToString(), "").Replace(PaddingCharacter.ToString(), "");
+            string decoded = TrimCode(code);
             int decodedCodeLength = Math.Min(decoded.Length, MaxCodeLength);
 
             int digit = 0;
             // The precisions are initially set to ENCODING_BASE^2 because they will be immediately divided.
-            decimal latPrecision = EncodingBaseSquared;
-            decimal lngPrecision = EncodingBaseSquared;
+            double latPrecision = EncodingBaseSquared;
+            double lngPrecision = EncodingBaseSquared;
             // Save the coordinates.
-            decimal southLatitude = 0;
-            decimal westLongitude = 0;
+            double southLatitude = 0;
+            double westLongitude = 0;
 
             // Decode the digits.
             while (digit < decodedCodeLength) {
@@ -197,18 +260,18 @@ namespace Google.OpenLocationCode {
                     // Decode a pair of digits, the first being latitude and the second being longitude.
                     latPrecision /= EncodingBase;
                     lngPrecision /= EncodingBase;
-                    int digitVal = CodeAlphabet.IndexOf(decoded[digit]);
+                    int digitVal = DigitValueOf(decoded[digit]);
                     southLatitude += latPrecision * digitVal;
-                    digitVal = CodeAlphabet.IndexOf(decoded[digit + 1]);
+                    digitVal = DigitValueOf(decoded[digit + 1]);
                     westLongitude += lngPrecision * digitVal;
                     digit += 2;
                 } else {
                     // Use the 4x5 grid for digits after 10.
-                    int digitVal = CodeAlphabet.IndexOf(decoded[digit]);
-                    int row = digitVal / GridColumns;
-                    int col = digitVal % GridColumns;
-                    latPrecision /= GridRows;
-                    lngPrecision /= GridColumns;
+                    int digitVal = DigitValueOf(decoded[digit]);
+                    int row = digitVal / RefinementGridColumns;
+                    int col = digitVal % RefinementGridColumns;
+                    latPrecision /= RefinementGridRows;
+                    lngPrecision /= RefinementGridColumns;
                     southLatitude += latPrecision * row;
                     westLongitude += lngPrecision * col;
                     digit += 1;
@@ -223,19 +286,16 @@ namespace Google.OpenLocationCode {
         }
 
         /// <summary>
-        /// Decodes the provided Open Location Code into CodeArea object encapsulating latitude/longitude bounding box.
+        /// Decodes this Open Location Code into CodeArea object encapsulating latitude/longitude bounding box.
         /// </summary>
-        /// <returns>The decode.</returns>
-        /// <param name="code">The Open Location Code to be decoded.</param>
-        /// <exception cref="ArgumentException">If the code is not valid.</exception>
-        /// <exception cref="InvalidOperationException">If the code is not full.</exception>
-        public static CodeArea Decode(string code) {
-            return new OpenLocationCode(code).Decode();
-        }
+        /// <returns>The decoded CodeArea for this Open Location Code.</returns>
+        /// <exception cref="InvalidOperationException">If this code is not full.</exception>
+        public CodeArea Decode() => _codeArea.Value;
+
 
         /// <returns><c>true</c>, if this Open Location Code is full, <c>false</c> otherwise.</returns>
         public bool IsFull() {
-            return Code.IndexOf(Separator) == SeparatorPosition;
+            return IsCodeFull(Code);
         }
 
         /// <returns><c>true</c>, if the provided Open Location Code is full, <c>false</c> otherwise.</returns>
@@ -245,9 +305,24 @@ namespace Google.OpenLocationCode {
             return new OpenLocationCode(code).IsFull();
         }
 
+        /// <returns><c>true</c>, if the code is a valid full Open Location Code, <c>false</c> otherwise.</returns>
+        /// <param name="code">The code to check.</param>
+        public static bool IsFullCode(string code) {
+            try {
+                return new OpenLocationCode(code).IsFull();
+            } catch (ArgumentException) {
+                return false;
+            }
+        }
+
+        private static bool IsCodeFull(string code) {
+            return code.IndexOf(SeparatorCharacter) == SeparatorPosition;
+        }
+
+
         /// <returns><c>true</c>, if this Open Location Code is short, <c>false</c> otherwise.</returns>
         public bool IsShort() {
-            var separatorIndex = Code.IndexOf(Separator);
+            int separatorIndex = Code.IndexOf(SeparatorCharacter);
             return separatorIndex >= 0 && separatorIndex < SeparatorPosition;
         }
 
@@ -258,11 +333,12 @@ namespace Google.OpenLocationCode {
             return new OpenLocationCode(code).IsShort();
         }
 
+
         /// <summary>
         /// An Open Location Code is padded when it contains less than 8 valid digits
         /// </summary>
         /// <returns><c>true</c>, if this Open Location Code is a padded, <c>false</c> otherwise.</returns>
-        private bool IsPadded() {
+        public bool IsPadded() {
             return Code.IndexOf(PaddingCharacter) >= 0;
         }
 
@@ -294,10 +370,10 @@ namespace Google.OpenLocationCode {
                 throw new InvalidOperationException("Shorten() method can not be called on a padded code.");
             }
 
-            CodeArea codeArea = Decode();
+            GeoCoord center = Decode().Center;
             double range = Math.Max(
-                Math.Abs(referenceLatitude - codeArea.CenterLatitude),
-                Math.Abs(referenceLongitude - codeArea.CenterLongitude)
+                Math.Abs(referenceLatitude - center.Latitude),
+                Math.Abs(referenceLongitude - center.Longitude)
             );
             // We are going to check to see if we can remove three pairs, two pairs or just one pair of
             // digits from the code.
@@ -327,7 +403,7 @@ namespace Google.OpenLocationCode {
             referenceLatitude = ClipLatitude(referenceLatitude);
             referenceLongitude = NormalizeLongitude(referenceLongitude);
 
-            int digitsToRecover = SeparatorPosition - Code.IndexOf(Separator);
+            int digitsToRecover = SeparatorPosition - Code.IndexOf(SeparatorCharacter);
             // The precision (height and width) of the missing prefix in degrees.
             double prefixPrecision = Math.Pow(EncodingBase, 2 - (digitsToRecover / 2));
 
@@ -336,11 +412,11 @@ namespace Google.OpenLocationCode {
                 new OpenLocationCode(referenceLatitude, referenceLongitude).Code.Substring(0, digitsToRecover);
             // Combine the prefix with the short code and decode it.
             OpenLocationCode recovered = new OpenLocationCode(recoveredPrefix + Code);
-            CodeArea recoveredCodeArea = recovered.Decode();
+            GeoCoord recoveredCodeAreaCenter = recovered.Decode().Center;
             // Work out whether the new code area is too far from the reference location. If it is, we
             // move it. It can only be out by a single precision step.
-            double recoveredLatitude = recoveredCodeArea.CenterLatitude;
-            double recoveredLongitude = recoveredCodeArea.CenterLongitude;
+            double recoveredLatitude = recoveredCodeAreaCenter.Latitude;
+            double recoveredLongitude = recoveredCodeAreaCenter.Longitude;
 
             // Move the recovered latitude by one precision up or down if it is too far from the reference,
             // unless doing so would lead to an invalid latitude.
@@ -353,7 +429,7 @@ namespace Google.OpenLocationCode {
 
             // Move the recovered longitude by one precision up or down if it is too far from the
             // reference.
-            double longitudeDiff = recoveredCodeArea.CenterLongitude - referenceLongitude;
+            double longitudeDiff = recoveredCodeAreaCenter.Longitude - referenceLongitude;
             if (longitudeDiff > prefixPrecision / 2) {
                 recoveredLongitude -= prefixPrecision;
             } else if (longitudeDiff < -prefixPrecision / 2) {
@@ -363,16 +439,28 @@ namespace Google.OpenLocationCode {
             return new OpenLocationCode(recoveredLatitude, recoveredLongitude, recovered.Code.Length - 1);
         }
 
-        /// <returns>Whether the bounding box specified by the Open Location Code contains provided point.</returns>
+        /// <returns>Whether the bounding box specified by this Open Location Code contains provided point.</returns>
+        /// <remarks>Convenient alternative to AreaData.Contains()</remarks>
         /// <param name="latitude">The latitude in decimal degrees.</param>
         /// <param name="longitude">The longitude in decimal degrees.</param>
+        /// <exception cref="InvalidOperationException">If this code is not full.</exception>
         public bool Contains(double latitude, double longitude) {
-            CodeArea codeArea = Decode();
-            return codeArea.SouthLatitude <= latitude
-                && latitude < codeArea.NorthLatitude
-                && codeArea.WestLongitude <= longitude
-                && longitude < codeArea.EastLongitude;
+            return Decode().Contains(longitude, latitude);
         }
+
+
+        /// <returns>A new OpenLocationCode instance representing the parent code area</returns>
+        /// <exception cref="InvalidOperationException">If this code top-level (length == 2)</exception>
+        public OpenLocationCode Parent() {
+            string code = TrimCode(Code);
+            if (code.Length == 2) {
+                throw new InvalidOperationException("Method Parent() cannot be called on top-level codes.");
+            }
+
+            int length = code.Length - (code.Length > SeparatorPosition ? 1 : 2);
+            return new OpenLocationCode(code.ToCharArray(0, length));
+        }
+
 
         public override bool Equals(object obj) {
             if (this == obj) {
@@ -396,17 +484,20 @@ namespace Google.OpenLocationCode {
 
         /** Returns whether the provided string is a valid Open Location code. */
         public static bool IsValidCode(string code) {
-            if (code == null || code.Length < 2) {
+            return code != null && IsValidCodeUpperCase(code.ToUpper());
+        }
+
+        private static bool IsValidCodeUpperCase(string code) {
+            if (code.Length < 2) {
                 return false;
             }
-            code = code.ToUpper();
 
             // There must be exactly one separator.
-            int separatorPosition = code.IndexOf(Separator);
+            int separatorPosition = code.IndexOf(SeparatorCharacter);
             if (separatorPosition == -1) {
                 return false;
             }
-            if (separatorPosition != code.LastIndexOf(Separator)) {
+            if (separatorPosition != code.LastIndexOf(SeparatorCharacter)) {
                 return false;
             }
 
@@ -417,12 +508,12 @@ namespace Google.OpenLocationCode {
             // Check first two characters: only some values from the alphabet are permitted.
             if (separatorPosition == 8) {
                 // First latitude character can only have first 9 values.
-                if (CodeAlphabet.IndexOf(code[0]) > 8) {
+                if (CodeAlphabet.IndexOf(code[0]) > FirstLatitudeDigitValueMax) {
                     return false;
                 }
 
                 // First longitude character can only have first 18 values.
-                if (CodeAlphabet.IndexOf(code[1]) > 17) {
+                if (CodeAlphabet.IndexOf(code[1]) > FirstLongitudeDigitValueMax) {
                     return false;
                 }
             }
@@ -471,16 +562,6 @@ namespace Google.OpenLocationCode {
         }
 
 
-        /// <returns><c>true</c>, if the code is a valid full Open Location Code, <c>false</c> otherwise.</returns>
-        /// <param name="code">The code to check.</param>
-        public static bool IsFullCode(string code) {
-            try {
-                return new OpenLocationCode(code).IsFull();
-            } catch (ArgumentException) {
-                return false;
-            }
-        }
-
         /// <returns><c>true</c>, if the code is a valid short Open Location Code, <c>false</c> otherwise.</returns>
         /// <param name="code">The code to check</param>
         public static bool IsShortCode(string code) {
@@ -491,7 +572,42 @@ namespace Google.OpenLocationCode {
             }
         }
 
+        /// <summary>
+        /// This will simply append padding '0' characters and append or insert the separator '+' character if necessary.
+        /// </summary>
+        /// <param name="code">The trimmed code to pad into a valid code</param>
+        /// <returns>A padded code from a trimmed code (without any validation)</returns>
+        public static string PadCode(string code) {
+            if (code.Length < SeparatorPosition) {
+                return code + new string(PaddingCharacter, SeparatorPosition - code.Length) + SeparatorCharacter;
+            } else if (code.Length == SeparatorPosition) {
+                return code + SeparatorCharacter;
+            } else if (code[SeparatorPosition] != SeparatorCharacter) {
+                return code.Substring(0, SeparatorPosition) + SeparatorCharacter + code.Substring(SeparatorPosition);
+            }
+            return code;
+        }
+
+        /// <summary>
+        /// Trim or strip unnecessary characters from a location code. simply by removing any padding '0' and separator '+' characters.
+        /// </summary>
+        /// <param name="code">the code to trim</param>
+        /// <returns>A trimmed code from a padded code (without any validation)</returns>
+        public static string TrimCode(string code) {
+            StringBuilder codeBuilder = new StringBuilder();
+            foreach (char c in code) {
+                if (c != PaddingCharacter && c != SeparatorCharacter) {
+                    codeBuilder.Append(c);
+                }
+            }
+            return codeBuilder.ToString();
+        }
+
         // Private static methods.
+
+        internal static int DigitValueOf(char digitChar) {
+            return IndexedDigitValues[digitChar - IndexedDigitValueOffset];
+        }
 
         private static double ClipLatitude(double latitude) {
             return Math.Min(Math.Max(latitude, -LatitudeMax), LatitudeMax);
@@ -517,7 +633,7 @@ namespace Google.OpenLocationCode {
             if (codeLength <= CodePrecisionNormal) {
                 return Math.Pow(EncodingBase, codeLength / -2 + 2);
             }
-            return Math.Pow(EncodingBase, -3) / Math.Pow(GridRows, codeLength - PairCodeLength);
+            return Math.Pow(EncodingBase, -3) / Math.Pow(RefinementGridRows, codeLength - PairCodeLength);
         }
 
     }

--- a/OpenLocationCode/OpenLocationCode.nuspec
+++ b/OpenLocationCode/OpenLocationCode.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>OpenLocationCode</id>
-    <version>1.0.3</version>
+    <version>1.1.0</version>
     <title>OpenLocationCode</title>
     <authors>Jon McPherson</authors>
     <owners>JonMcPherson</owners>

--- a/OpenLocationCodeTest/EncodingTest.cs
+++ b/OpenLocationCodeTest/EncodingTest.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using Google.OpenLocationCode;
-using Xunit;
+using NUnit.Framework;
 
-public class EncodingTest {
+public static class EncodingTest {
 
     private static readonly List<TestData> TestDataList = new List<TestData> {
         new TestData("7FG49Q00+", 20.375, 2.775, 20.35, 2.75, 20.4, 2.8),
@@ -27,43 +27,43 @@ public class EncodingTest {
     };
 
     public class TheEncodeMethod {
-        [Fact]
+        [Test]
         public void ShouldEncodePointToLocationCode() {
             foreach (var testData in TestDataList) {
                 int codeLength = testData.Code.Length - 1;
                 if (testData.Code.Contains("0")) {
                     codeLength = testData.Code.IndexOf("0");
                 }
-                Assert.True(testData.Code == OpenLocationCode.Encode(testData.Lat, testData.Lon, codeLength),
+                Assert.AreEqual(testData.Code, OpenLocationCode.Encode(testData.Lat, testData.Lon, codeLength),
                     $"Latitude {testData.Lat} and longitude {testData.Lon} were wrongly encoded.");
             }
         }
 
-        [Fact]
+        [Test]
         public void ShouldClipCoordinatesWhenExceedingMaximum() {
-            Assert.True(OpenLocationCode.Encode(-90, 5) == OpenLocationCode.Encode(-91, 5),
+            Assert.AreEqual(OpenLocationCode.Encode(-90, 5), OpenLocationCode.Encode(-91, 5),
                 "Clipping of negative latitude doesn't work.");
-            Assert.True(OpenLocationCode.Encode(90, 5) == OpenLocationCode.Encode(91, 5),
+            Assert.AreEqual(OpenLocationCode.Encode(90, 5), OpenLocationCode.Encode(91, 5),
                 "Clipping of positive latitude doesn't work.");
-            Assert.True(OpenLocationCode.Encode(5, 175) == OpenLocationCode.Encode(5, -185),
+            Assert.AreEqual(OpenLocationCode.Encode(5, 175), OpenLocationCode.Encode(5, -185),
                 "Clipping of negative longitude doesn't work.");
-            Assert.True(OpenLocationCode.Encode(5, 175) == OpenLocationCode.Encode(5, -905),
+            Assert.AreEqual(OpenLocationCode.Encode(5, 175), OpenLocationCode.Encode(5, -905),
                 "Clipping of very long negative longitude doesn't work.");
-            Assert.True(OpenLocationCode.Encode(5, -175) == OpenLocationCode.Encode(5, 905),
+            Assert.AreEqual(OpenLocationCode.Encode(5, -175), OpenLocationCode.Encode(5, 905),
                 "Clipping of very long positive longitude doesn't work.");
         }
 
-        [Fact]
+        [Test]
         public void ShouldLimitCodeLengthWhenExceedingMaximum() {
             string code = OpenLocationCode.Encode(51.3701125, -10.202665625, 1000000);
 
-            Assert.True(code.Length == OpenLocationCode.MaxCodeLength + 1,
+            Assert.AreEqual(code.Length, OpenLocationCode.MaxCodeLength + 1,
                 "Encoded code should have a length of MaxCodeLength + 1 for the plus symbol");
         }
     }
 
     public class TheDecodeMethod {
-        [Fact]
+        [Test]
         public void ShouldDecodeLocationCodeToExpectedCodeArea() {
             foreach (var testData in TestDataList) {
                 var decoded = OpenLocationCode.Decode(testData.Code);
@@ -79,7 +79,7 @@ public class EncodingTest {
             }
         }
 
-        [Fact]
+        [Test]
         public void ShouldDecodeToCodeAreaWithValidContainmentRelation() {
             foreach (var testData in TestDataList) {
                 var olc = new OpenLocationCode(testData.Code);
@@ -97,20 +97,22 @@ public class EncodingTest {
             }
         }
 
-        [Fact]
+        [Test]
         public void ShouldDecodeToCodeAreaWithExpectedDimensions() {
-            Assert.Equal(OpenLocationCode.Decode("67000000+").LongitudeWidth, 20.0, 0);
-            Assert.Equal(OpenLocationCode.Decode("67000000+").LatitudeHeight, 20.0, 0);
-            Assert.Equal(OpenLocationCode.Decode("67890000+").LongitudeWidth, 1.0, 0);
-            Assert.Equal(OpenLocationCode.Decode("67890000+").LatitudeHeight, 1.0, 0);
-            Assert.Equal(OpenLocationCode.Decode("6789CF00+").LongitudeWidth, 0.05, 0);
-            Assert.Equal(OpenLocationCode.Decode("6789CF00+").LatitudeHeight, 0.05, 0);
-            Assert.Equal(OpenLocationCode.Decode("6789CFGH+").LongitudeWidth, 0.0025, 0);
-            Assert.Equal(OpenLocationCode.Decode("6789CFGH+").LatitudeHeight, 0.0025, 0);
-            Assert.Equal(OpenLocationCode.Decode("6789CFGH+JM").LongitudeWidth, 0.000125, 0);
-            Assert.Equal(OpenLocationCode.Decode("6789CFGH+JM").LatitudeHeight, 0.000125, 0);
-            Assert.Equal(OpenLocationCode.Decode("6789CFGH+JMP").LongitudeWidth, 0.00003125, 0);
-            Assert.Equal(OpenLocationCode.Decode("6789CFGH+JMP").LatitudeHeight, 0.000025, 0);
+            Assert.AreEqual(20.0, OpenLocationCode.Decode("67000000+").LongitudeWidth, 0);
+            Assert.AreEqual(20.0, OpenLocationCode.Decode("67000000+").LatitudeHeight, 0);
+            Assert.AreEqual(1.0, OpenLocationCode.Decode("67890000+").LongitudeWidth, 0);
+            Assert.AreEqual(1.0, OpenLocationCode.Decode("67890000+").LatitudeHeight, 0);
+            Assert.AreEqual(0.05, OpenLocationCode.Decode("6789CF00+").LongitudeWidth, 0);
+            Assert.AreEqual(0.05, OpenLocationCode.Decode("6789CF00+").LatitudeHeight, 0);
+            Assert.AreEqual(0.0025, OpenLocationCode.Decode("6789CFGH+").LongitudeWidth, 0);
+            Assert.AreEqual(0.0025, OpenLocationCode.Decode("6789CFGH+").LatitudeHeight, 0);
+            Assert.AreEqual(0.000125, OpenLocationCode.Decode("6789CFGH+JM").LongitudeWidth, 0);
+            Assert.AreEqual(0.000125, OpenLocationCode.Decode("6789CFGH+JM").LatitudeHeight, 0);
+            Assert.AreEqual(0.00003125, OpenLocationCode.Decode("6789CFGH+JMP").LongitudeWidth, 0);
+            Assert.AreEqual(0.000025, OpenLocationCode.Decode("6789CFGH+JMP").LatitudeHeight, 0);
+
+
         }
 
         private bool IsNear(double a, double b) {

--- a/OpenLocationCodeTest/EncodingTest.cs
+++ b/OpenLocationCodeTest/EncodingTest.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 public class EncodingTest {
 
-    private static readonly List<TestData> testDataList = new List<TestData> {
+    private static readonly List<TestData> TestDataList = new List<TestData> {
         new TestData("7FG49Q00+", 20.375, 2.775, 20.35, 2.75, 20.4, 2.8),
         new TestData("7FG49QCJ+2V", 20.3700625, 2.7821875, 20.37, 2.782125, 20.370125, 2.78225),
         new TestData("7FG49QCJ+2VX", 20.3701125, 2.782234375, 20.3701, 2.78221875, 20.370125, 2.78225),
@@ -29,7 +29,7 @@ public class EncodingTest {
     public class TheEncodeMethod {
         [Fact]
         public void ShouldEncodePointToLocationCode() {
-            foreach (var testData in testDataList) {
+            foreach (var testData in TestDataList) {
                 int codeLength = testData.Code.Length - 1;
                 if (testData.Code.Contains("0")) {
                     codeLength = testData.Code.IndexOf("0");
@@ -65,7 +65,7 @@ public class EncodingTest {
     public class TheDecodeMethod {
         [Fact]
         public void ShouldDecodeLocationCodeToExpectedCodeArea() {
-            foreach (var testData in testDataList) {
+            foreach (var testData in TestDataList) {
                 var decoded = OpenLocationCode.Decode(testData.Code);
 
                 Assert.True(IsNear(testData.DecodedLatLo, decoded.SouthLatitude),
@@ -81,7 +81,7 @@ public class EncodingTest {
 
         [Fact]
         public void ShouldDecodeToCodeAreaWithValidContainmentRelation() {
-            foreach (var testData in testDataList) {
+            foreach (var testData in TestDataList) {
                 var olc = new OpenLocationCode(testData.Code);
                 var decoded = olc.Decode();
                 Assert.True(olc.Contains(decoded.CenterLatitude, decoded.CenterLongitude),

--- a/OpenLocationCodeTest/OpenLocationCodeTest.csproj
+++ b/OpenLocationCodeTest/OpenLocationCodeTest.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenLocationCodeTest/ShorteningTest.cs
+++ b/OpenLocationCodeTest/ShorteningTest.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using Google.OpenLocationCode;
-using Xunit;
+using NUnit.Framework;
 
 public static class ShorteningTest {
-    
+
     private static readonly List<TestData> TestDataList = new List<TestData> {
         new TestData("9C3W9QCJ+2VX", 51.3701125, -1.217765625, "+2VX", "B"),
         // Adjust so we can't trim by 8 (+/- .000755)
@@ -34,7 +34,7 @@ public static class ShorteningTest {
     };
 
     public class TheShortenMethod {
-        [Fact]
+        [Test]
         public void ShouldShortenLongCodeToShortCodeFromReferencePoint() {
             foreach (var testData in TestDataList) {
                 if (testData.TestType != "B" && testData.TestType != "S") {
@@ -42,13 +42,13 @@ public static class ShorteningTest {
                 }
                 OpenLocationCode olc = new OpenLocationCode(testData.Code);
                 OpenLocationCode shortened = olc.Shorten(testData.ReferenceLatitude, testData.ReferenceLongitude);
-                Assert.Equal(testData.ShortCode, shortened.Code);
+                Assert.AreEqual(testData.ShortCode, shortened.Code);
             }
         }
     }
 
     public class TheRecoverMethod {
-        [Fact]
+        [Test]
         public void ShouldRecoverShortCodeToLongCodeFromReferencePoint() {
             foreach (var testData in TestDataList) {
                 if (testData.TestType != "B" && testData.TestType != "R") {
@@ -56,20 +56,20 @@ public static class ShorteningTest {
                 }
                 OpenLocationCode olc = new OpenLocationCode(testData.ShortCode);
                 OpenLocationCode recovered = olc.Recover(testData.ReferenceLatitude, testData.ReferenceLongitude);
-                Assert.Equal(testData.Code, recovered.Code);
+                Assert.AreEqual(testData.Code, recovered.Code);
             }
         }
 
-        [Fact]
+        [Test]
         public void ShouldRecoverShortCodesNearSouthPole() {
             OpenLocationCode olc = new OpenLocationCode("XXXXXX+XX");
-            Assert.Equal("2CXXXXXX+XX", olc.Recover(-81.0, 0.0).Code);
+            Assert.AreEqual("2CXXXXXX+XX", olc.Recover(-81.0, 0.0).Code);
         }
 
-        [Fact]
+        [Test]
         public void ShouldRecoverShortCodesNearNorthPole() {
             OpenLocationCode olc = new OpenLocationCode("2222+22");
-            Assert.Equal("CFX22222+22", olc.Recover(89.6, 0.0).Code);
+            Assert.AreEqual("CFX22222+22", olc.Recover(89.6, 0.0).Code);
         }
     }
 

--- a/OpenLocationCodeTest/ShorteningTest.cs
+++ b/OpenLocationCodeTest/ShorteningTest.cs
@@ -3,8 +3,8 @@ using Google.OpenLocationCode;
 using Xunit;
 
 public static class ShorteningTest {
-
-    private static readonly List<TestData> testDataList = new List<TestData> {
+    
+    private static readonly List<TestData> TestDataList = new List<TestData> {
         new TestData("9C3W9QCJ+2VX", 51.3701125, -1.217765625, "+2VX", "B"),
         // Adjust so we can't trim by 8 (+/- .000755)
         new TestData("9C3W9QCJ+2VX", 51.3708675, -1.217765625, "CJ+2VX", "B"),
@@ -36,7 +36,7 @@ public static class ShorteningTest {
     public class TheShortenMethod {
         [Fact]
         public void ShouldShortenLongCodeToShortCodeFromReferencePoint() {
-            foreach (var testData in testDataList) {
+            foreach (var testData in TestDataList) {
                 if (testData.TestType != "B" && testData.TestType != "S") {
                     continue;
                 }
@@ -50,7 +50,7 @@ public static class ShorteningTest {
     public class TheRecoverMethod {
         [Fact]
         public void ShouldRecoverShortCodeToLongCodeFromReferencePoint() {
-            foreach (var testData in testDataList) {
+            foreach (var testData in TestDataList) {
                 if (testData.TestType != "B" && testData.TestType != "R") {
                     continue;
                 }

--- a/OpenLocationCodeTest/ValidityTest.cs
+++ b/OpenLocationCodeTest/ValidityTest.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 public static class ValidityTest {
 
-    private static readonly List<TestData> testDataList = new List<TestData> {
+    private static readonly List<TestData> TestDataList = new List<TestData> {
         new TestData("8FWC2345+G6", true, false, true),
         new TestData("8FWC2345+G6G", true, false, true),
         new TestData("8fwc2345+", true, false, true),
@@ -30,7 +30,7 @@ public static class ValidityTest {
     public class TheIsValidCodeMethod {
         [Fact]
         public void ShouldTestValidityOfACode() {
-            foreach (TestData testData in testDataList) {
+            foreach (TestData testData in TestDataList) {
                 Assert.True(testData.IsValid == OpenLocationCode.IsValidCode(testData.Code),
                     $"Validity of code {testData.Code} is wrong.");
             }
@@ -54,7 +54,7 @@ public static class ValidityTest {
     public class TheIsShortCodeMethod {
         [Fact]
         public void ShouldTestShortnessOfACode() {
-            foreach (TestData testData in testDataList) {
+            foreach (TestData testData in TestDataList) {
                 Assert.True(testData.IsShort == OpenLocationCode.IsShortCode(testData.Code),
                     $"Shortness of code {testData.Code} is wrong.");
             }
@@ -64,7 +64,7 @@ public static class ValidityTest {
     public class TheIsFullCodeMethod {
         [Fact]
         public void ShouldTestFullnessOfACode() {
-            foreach (TestData testData in testDataList) {
+            foreach (TestData testData in TestDataList) {
                 Assert.True(testData.IsFull == OpenLocationCode.IsFullCode(testData.Code),
                     $"Fullness of code {testData.Code} is wrong.");
             }

--- a/OpenLocationCodeTest/ValidityTest.cs
+++ b/OpenLocationCodeTest/ValidityTest.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using Google.OpenLocationCode;
-using Xunit;
+using NUnit.Framework;
 
 public static class ValidityTest {
 
@@ -28,15 +28,15 @@ public static class ValidityTest {
 
 
     public class TheIsValidCodeMethod {
-        [Fact]
+        [Test]
         public void ShouldTestValidityOfACode() {
             foreach (TestData testData in TestDataList) {
-                Assert.True(testData.IsValid == OpenLocationCode.IsValidCode(testData.Code),
+                Assert.AreEqual(testData.IsValid, OpenLocationCode.IsValidCode(testData.Code),
                     $"Validity of code {testData.Code} is wrong.");
             }
         }
 
-        [Fact]
+        [Test]
         public void ShouldValidateCodesExceedingMaximumLength() {
             string code = OpenLocationCode.Encode(51.3701125, -10.202665625, 1000000);
             Assert.True(OpenLocationCode.IsValidCode(code), "Code should be valid.");
@@ -52,20 +52,20 @@ public static class ValidityTest {
     }
 
     public class TheIsShortCodeMethod {
-        [Fact]
+        [Test]
         public void ShouldTestShortnessOfACode() {
             foreach (TestData testData in TestDataList) {
-                Assert.True(testData.IsShort == OpenLocationCode.IsShortCode(testData.Code),
+                Assert.AreEqual(testData.IsShort, OpenLocationCode.IsShortCode(testData.Code),
                     $"Shortness of code {testData.Code} is wrong.");
             }
         }
     }
 
     public class TheIsFullCodeMethod {
-        [Fact]
+        [Test]
         public void ShouldTestFullnessOfACode() {
             foreach (TestData testData in TestDataList) {
-                Assert.True(testData.IsFull == OpenLocationCode.IsFullCode(testData.Code),
+                Assert.AreEqual(testData.IsFull, OpenLocationCode.IsFullCode(testData.Code),
                     $"Fullness of code {testData.Code} is wrong.");
             }
         }


### PR DESCRIPTION
- Add GeoPoint struct to better encapsulate a set of latitude and longitude coordinates
- Add Parent() method to get the "parent" OLC
- Add TrimCode() and PadCode() utility methods
- Add minor efficiency improvements
  * Indexed code digit lookup
  * Fix code.ToUpper() redundancy
  * Switch from decimal to double for internal calculations
  * Compute CodeArea height/width and center point on demand and not on instantiation
- Add unit test for lowercase codes
- Switch to NUnit test framework
- Fix and improve documentation